### PR TITLE
Add CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,146 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# Visual Studio Code
 .vscode
+
 bin
 include
-lib
 .token
 pyvenv.cfg

--- a/domains.txt
+++ b/domains.txt
@@ -1,0 +1,2 @@
+default_config
+demo

--- a/make.py
+++ b/make.py
@@ -137,6 +137,7 @@ def common_issue_options(func):
     func = click.option(
         "-b",
         "--body",
+        required=True,
         type=click.Path(exists=True, dir_okay=False),
         help="Set file path to a markdown file with issue body.",
     )(func)
@@ -180,8 +181,8 @@ def create_issue(silent, owner, repo, token, username, title, body, labels, **kw
                 "Token must be provided by promt or in a '.token' file"
             )
             return
-    if body:
-        body = Path(body).read_text()
+
+    body = Path(body).read_text()
 
     # Authentication for user filing issue (must have read/write access to
     # repository to add issue to)
@@ -199,8 +200,7 @@ def create_issue(silent, owner, repo, token, username, title, body, labels, **kw
     domain_labels = None
     for domain in domain_names:
         domain_title = title.replace("{{ DOMAIN }}", domain)
-        if body:
-            domain_body = body.replace("{{ DOMAIN }}", domain)
+        domain_body = body.replace("{{ DOMAIN }}", domain)
         if labels:
             domain_labels = labels + (f"integration: {domain}",)
 

--- a/make.py
+++ b/make.py
@@ -7,10 +7,6 @@ from pprint import pprint
 import click
 import requests
 
-# Authentication for user filing issue (must have read/write access to
-# repository to add issue to)
-USERNAME = "balloob"
-
 # The repository to add this issue to
 REPO_OWNER = "home-assistant"
 REPO_NAME = "core"
@@ -118,6 +114,7 @@ def common_issue_options(func):
     func = click.option(
         "-u",
         "--username",
+        required=True,
         help="Set the github username.",
     )(func)
     func = click.option(
@@ -175,10 +172,12 @@ def issue(silent, owner, repo, token, username, title, body, labels, domains, **
     """Create issue on github.com."""
     repo_name = repo or REPO_NAME
     repo_owner = owner or REPO_OWNER
-    username = username or USERNAME
     token = token or Path(".token").read_text().strip()
     if body:
         body = Path(body).read_text()
+
+    # Authentication for user filing issue (must have read/write access to
+    # repository to add issue to)
     auth = Auth(
         repo_name=repo_name, repo_owner=repo_owner, username=username, token=token
     )

--- a/make.py
+++ b/make.py
@@ -105,27 +105,27 @@ def common_issue_options(func):
         "--token",
         prompt=True,
         hide_input=True,
-        help="Set the github auth token.",
+        help="Set the auth token.",
     )(func)
     func = click.option(
         "-R",
         "--repo",
         default=REPO_NAME,
         show_default=True,
-        help="Set the github target repo.",
+        help="Set the target repo.",
     )(func)
     func = click.option(
         "-u",
         "--username",
         required=True,
-        help="Set the github username.",
+        help="Set the username.",
     )(func)
     func = click.option(
         "-O",
         "--owner",
         default=REPO_OWNER,
         show_default=True,
-        help="Set the github repository owner.",
+        help="Set the repository owner.",
     )(func)
     func = click.option(
         "-T",

--- a/make.py
+++ b/make.py
@@ -1,3 +1,4 @@
+"""Make issues on github.com."""
 from pathlib import Path
 from pprint import pprint
 
@@ -47,7 +48,7 @@ def make_github_issue(
 
 
 def make_github_issue_no_notify(token, title, body, labels):
-    """Does not fire webhooks or create notifications."""
+    """Create issues while not firing webhooks or creating notifications."""
     # Create an issue on github.com using the given parameters
     # Url to create issues via POST
     url = "https://api.github.com/repos/%s/%s/import/issues" % (REPO_OWNER, REPO_NAME)

--- a/make.py
+++ b/make.py
@@ -110,6 +110,8 @@ def common_issue_options(func):
     func = click.option(
         "-R",
         "--repo",
+        default=REPO_NAME,
+        show_default=True,
         help="Set the github target repo.",
     )(func)
     func = click.option(
@@ -121,6 +123,8 @@ def common_issue_options(func):
     func = click.option(
         "-O",
         "--owner",
+        default=REPO_OWNER,
+        show_default=True,
         help="Set the github repository owner.",
     )(func)
     func = click.option(
@@ -172,17 +176,13 @@ def cli():
 @common_issue_options
 def issue(silent, owner, repo, token, username, title, body, labels, domains, **kwargs):
     """Create issue on github.com."""
-    repo_name = repo or REPO_NAME
-    repo_owner = owner or REPO_OWNER
     token = token or Path(".token").read_text().strip()
     if body:
         body = Path(body).read_text()
 
     # Authentication for user filing issue (must have read/write access to
     # repository to add issue to)
-    auth = Auth(
-        repo_name=repo_name, repo_owner=repo_owner, username=username, token=token
-    )
+    auth = Auth(repo_name=repo, repo_owner=owner, username=username, token=token)
 
     issue_func = partial(make_github_issue, auth, **kwargs)
 

--- a/make.py
+++ b/make.py
@@ -144,7 +144,6 @@ def common_issue_options(func):
     func = click.option(
         "-a",
         "--assignee",
-        show_default=True,
         help="Set the issue assignee.",
     )(func)
     func = click.option(

--- a/make.py
+++ b/make.py
@@ -139,7 +139,7 @@ def common_issue_options(func):
         "--body",
         required=True,
         type=click.Path(exists=True, dir_okay=False),
-        help="Set file path to a markdown file with issue body.",
+        help="Set path to a text file with issue body.",
     )(func)
     func = click.option(
         "-a",

--- a/make.py
+++ b/make.py
@@ -171,7 +171,15 @@ def cli():
 @common_issue_options
 def create_issue(silent, owner, repo, token, username, title, body, labels, **kwargs):
     """Create issue on github.com."""
-    token = token or Path(".token").read_text().strip()
+    if not token:
+        try:
+            token = Path(".token").read_text().strip()
+        except FileNotFoundError:
+            print(
+                "Missing '.token' file. "
+                "Token must be provided by promt or in a '.token' file"
+            )
+            return
     if body:
         body = Path(body).read_text()
 

--- a/make.py
+++ b/make.py
@@ -98,65 +98,6 @@ def make_github_issue_no_notify(auth, title, body, labels):
         print("Response:", response.content)
 
 
-def common_issue_options(func):
-    """Supply common issue options."""
-    func = click.option(
-        "-t",
-        "--token",
-        prompt=True,
-        hide_input=True,
-        default="",
-        help="Set the auth token.",
-    )(func)
-    func = click.option(
-        "-R",
-        "--repo",
-        default=REPO_NAME,
-        show_default=True,
-        help="Set the target repo.",
-    )(func)
-    func = click.option(
-        "-u",
-        "--username",
-        required=True,
-        help="Set the username.",
-    )(func)
-    func = click.option(
-        "-O",
-        "--owner",
-        default=REPO_OWNER,
-        show_default=True,
-        help="Set the repository owner.",
-    )(func)
-    func = click.option(
-        "-T",
-        "--title",
-        required=True,
-        help="Set the issue title.",
-    )(func)
-    func = click.option(
-        "-b",
-        "--body",
-        required=True,
-        type=click.Path(exists=True, dir_okay=False),
-        help="Set path to a text file with issue body.",
-    )(func)
-    func = click.option(
-        "-a",
-        "--assignee",
-        help="Set the issue assignee.",
-    )(func)
-    func = click.option(
-        "-m",
-        "--milestone",
-        help="Set the issue milestone.",
-    )(func)
-    func = click.option("-l", "--labels", multiple=True, help="Set the issue labels.")(
-        func
-    )
-    return func
-
-
 @click.group(
     options_metavar="", subcommand_metavar="<command>", context_settings=SETTINGS
 )
@@ -168,7 +109,58 @@ def cli():
 @click.option(
     "-s", "--silent", is_flag=True, help="Make an issue without notifications."
 )
-@common_issue_options
+@click.option(
+    "-t",
+    "--token",
+    prompt=True,
+    hide_input=True,
+    default="",
+    help="Set the auth token.",
+)
+@click.option(
+    "-R",
+    "--repo",
+    default=REPO_NAME,
+    show_default=True,
+    help="Set the target repo.",
+)
+@click.option(
+    "-u",
+    "--username",
+    required=True,
+    help="Set the username.",
+)
+@click.option(
+    "-O",
+    "--owner",
+    default=REPO_OWNER,
+    show_default=True,
+    help="Set the repository owner.",
+)
+@click.option(
+    "-T",
+    "--title",
+    required=True,
+    help="Set the issue title.",
+)
+@click.option(
+    "-b",
+    "--body",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Set path to a text file with issue body.",
+)
+@click.option(
+    "-a",
+    "--assignee",
+    help="Set the issue assignee.",
+)
+@click.option(
+    "-m",
+    "--milestone",
+    help="Set the issue milestone.",
+)
+@click.option("-l", "--labels", multiple=True, help="Set the issue labels.")
 def create_issue(silent, owner, repo, token, username, title, body, labels, **kwargs):
     """Create issue on github.com."""
     if not token:

--- a/make.py
+++ b/make.py
@@ -105,6 +105,7 @@ def common_issue_options(func):
         "--token",
         prompt=True,
         hide_input=True,
+        default="",
         help="Set the auth token.",
     )(func)
     func = click.option(

--- a/make.py
+++ b/make.py
@@ -125,6 +125,7 @@ def common_issue_options(func):
     func = click.option(
         "-T",
         "--title",
+        required=True,
         help="Set the issue title.",
     )(func)
     func = click.option(
@@ -193,8 +194,7 @@ def issue(silent, owner, repo, token, username, title, body, labels, domains, **
         domain_body = None
         domain_labels = None
         for domain in domain_names:
-            if title:
-                domain_title = title.replace("{{ DOMAIN }}", domain)
+            domain_title = title.replace("{{ DOMAIN }}", domain)
             if body:
                 domain_body = body.replace("{{ DOMAIN }}", domain)
             if labels:

--- a/make.py
+++ b/make.py
@@ -170,12 +170,14 @@ def cli():
     """Batch create github.com issues."""
 
 
-@click.command(options_metavar="<options>")
+@click.command(name="issue", options_metavar="<options>")
 @click.option(
     "-s", "--silent", is_flag=True, help="Make an issue without notifications."
 )
 @common_issue_options
-def issue(silent, owner, repo, token, username, title, body, labels, domains, **kwargs):
+def create_issue(
+    silent, owner, repo, token, username, title, body, labels, domains, **kwargs
+):
     """Create issue on github.com."""
     token = token or Path(".token").read_text().strip()
     if body:
@@ -210,7 +212,7 @@ def issue(silent, owner, repo, token, username, title, body, labels, domains, **
     issue_func(title=title, body=body, labels=labels)
 
 
-cli.add_command(issue)
+cli.add_command(create_issue)
 
 
 if __name__ == "__main__":

--- a/make.py
+++ b/make.py
@@ -1,21 +1,23 @@
 from pathlib import Path
 from pprint import pprint
-from datetime import datetime
-import sys
+
+import click
 import requests
-import json
 
 # Authentication for user filing issue (must have read/write access to
 # repository to add issue to)
 USERNAME = "balloob"
-TOKEN = Path(".token").read_text().strip()
 
 # The repository to add this issue to
 REPO_OWNER = "home-assistant"
 REPO_NAME = "core"
 
+SETTINGS = dict(help_option_names=["-h", "--help"])
 
-def make_github_issue(title, body=None, assignee=None, milestone=None, labels=None):
+
+def make_github_issue(
+    token, title, body=None, assignee=None, milestone=None, labels=None
+):
     """Create an issue on github.com using the given parameters."""
     # Our url to create issues via POST
     url = "https://api.github.com/repos/%s/%s/issues" % (REPO_OWNER, REPO_NAME)
@@ -31,7 +33,7 @@ def make_github_issue(title, body=None, assignee=None, milestone=None, labels=No
 
     # Add the issue to our repository
     response = requests.post(
-        url, json=issue, headers={"Authorization": "token %s" % TOKEN}
+        url, json=issue, headers={"Authorization": f"token {token}"}
     )
 
     print(response.status_code)
@@ -44,7 +46,7 @@ def make_github_issue(title, body=None, assignee=None, milestone=None, labels=No
         print("Response:", response.content)
 
 
-def make_github_issue_no_notify(title, body, labels):
+def make_github_issue_no_notify(token, title, body, labels):
     """Does not fire webhooks or create notifications."""
     # Create an issue on github.com using the given parameters
     # Url to create issues via POST
@@ -52,7 +54,7 @@ def make_github_issue_no_notify(title, body, labels):
 
     # Headers
     headers = {
-        "Authorization": "token %s" % TOKEN,
+        "Authorization": f"token {token}",
         "Accept": "application/vnd.github.golden-comet-preview+json",
     }
 
@@ -84,46 +86,111 @@ def make_github_issue_no_notify(title, body, labels):
         print("Response:", response.content)
 
 
-template = Path("./issues/test_uncaught.markdown").read_text()
+def main():
+    """Old main function."""
+    context = {}
+    context["token"] = Path(".token").read_text().strip()
+    template = Path("./issues/test_uncaught.markdown").read_text()
 
-for domain in [
-    # "abode",
-    # "cast",
-    # "config",
-    "deconz",
-    "default_config",
-    "demo",
-    "discovery",
-    "dsmr",
-    "dynalite",
-    "dyson",
-    "gdacs",
-    "geonetnz_quakes",
-    "homematicip_cloud",
-    "hue",
-    "ios",
-    "local_file",
-    "meteo_france",
-    "mikrotik",
-    "mqtt",
-    "plex",
-    "qwikswitch",
-    "rflink",
-    "samsungtv",
-    "tplink",
-    "tradfri",
-    "unifi_direct",
-    "upnp",
-    "vera",
-    "wunderground",
-    "yr",
-    "zha",
-    "zwave",
-]:
-    title = f"Fix {domain} tests that have uncaught exceptions"
-    body = template.replace("{{ DOMAIN }}", domain)
-    labels = [f"integration: {domain}", "to do"]
-    # print(title)
-    # print(body)
-    # print(labels)
-    make_github_issue(title=title, body=body, labels=labels)
+    for domain in [
+        # "abode",
+        # "cast",
+        # "config",
+        "deconz",
+        "default_config",
+        "demo",
+        "discovery",
+        "dsmr",
+        "dynalite",
+        "dyson",
+        "gdacs",
+        "geonetnz_quakes",
+        "homematicip_cloud",
+        "hue",
+        "ios",
+        "local_file",
+        "meteo_france",
+        "mikrotik",
+        "mqtt",
+        "plex",
+        "qwikswitch",
+        "rflink",
+        "samsungtv",
+        "tplink",
+        "tradfri",
+        "unifi_direct",
+        "upnp",
+        "vera",
+        "wunderground",
+        "yr",
+        "zha",
+        "zwave",
+    ]:
+        title = f"Fix {domain} tests that have uncaught exceptions"
+        body = template.replace("{{ DOMAIN }}", domain)
+        labels = [f"integration: {domain}", "to do"]
+        # print(title)
+        # print(body)
+        # print(labels)
+        make_github_issue(title=title, body=body, labels=labels)
+
+
+def common_issue_options(func):
+    """Supply common issue options."""
+    func = click.option(
+        "-t",
+        "--token",
+        help="Set the github auth token.",
+    )(func)
+    func = click.option(
+        "-T",
+        "--title",
+        help="Set the issue title.",
+    )(func)
+    func = click.option(
+        "-b",
+        "--body",
+        help="Set the issue body.",
+    )(func)
+    func = click.option(
+        "-a",
+        "--assignee",
+        show_default=True,
+        help="Set the issue assignee.",
+    )(func)
+    func = click.option(
+        "-m",
+        "--milestone",
+        help="Set the issue milestone.",
+    )(func)
+    func = click.option("-l", "--label", multiple=True, help="Set the issue label.")(
+        func
+    )
+    return func
+
+
+@click.group(
+    options_metavar="", subcommand_metavar="<command>", context_settings=SETTINGS
+)
+def cli():
+    """Batch create github.com issues."""
+
+
+@click.command(options_metavar="<options>")
+@click.option(
+    "-s", "--silent", is_flag=True, help="Make an issue without notifications."
+)
+@common_issue_options
+def issue(silent, **kwargs):
+    """Create issue on github.com."""
+    if silent:
+        make_github_issue_no_notify(**kwargs)
+    else:
+        make_github_issue(**kwargs)
+
+
+cli.add_command(issue)
+
+
+if __name__ == "__main__":
+    cli()

--- a/make.py
+++ b/make.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Make issues on github.com."""
 from dataclasses import dataclass
 from functools import partial

--- a/make.py
+++ b/make.py
@@ -183,9 +183,10 @@ def issue(silent, owner, repo, token, username, title, body, labels, domains, **
         repo_name=repo_name, repo_owner=repo_owner, username=username, token=token
     )
 
-    issue_func = partial(make_github_issue, auth)
+    issue_func = partial(make_github_issue, auth, **kwargs)
 
     if silent:
+        # the import API doesn't accept optional values
         issue_func = partial(make_github_issue_no_notify, auth)
 
     if domains:
@@ -200,13 +201,11 @@ def issue(silent, owner, repo, token, username, title, body, labels, domains, **
             if labels:
                 domain_labels = labels + (f"integration: {domain}",)
 
-            issue_func(
-                title=domain_title, body=domain_body, labels=domain_labels, **kwargs
-            )
+            issue_func(title=domain_title, body=domain_body, labels=domain_labels)
 
         return
 
-    issue_func(title=title, body=body, labels=labels, **kwargs)
+    issue_func(title=title, body=body, labels=labels)
 
 
 cli.add_command(issue)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+click
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[flake8]
+ignore = E203, E231, W503
+max-line-length = 88
+
+[isort]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88
+
+[pydocstyle]
+add-ignore = D202


### PR DESCRIPTION
```
(github-issue-maker) x:~/dev/home-assistant/github-issue-maker$ ./make.py --help
Usage: make.py  <command>

  Batch create github.com issues.

Options:
  -h, --help  Show this message and exit.

Commands:
  issue  Create issue on github.com.

(github-issue-maker) x:~/dev/home-assistant/github-issue-maker$ ./make.py issue --help
Usage: make.py issue <options>

  Create issue on github.com.

Options:
  -s, --silent          Make an issue without notifications.
  -t, --token TEXT      Set the auth token.
  -R, --repo TEXT       Set the target repo.  [default: core]
  -u, --username TEXT   Set the username.  [required]
  -O, --owner TEXT      Set the repository owner.  [default: home-assistant]
  -T, --title TEXT      Set the issue title.  [required]
  -b, --body FILE       Set path to a text file with issue body.  [required]
  -a, --assignee TEXT   Set the issue assignee.
  -m, --milestone TEXT  Set the issue milestone.
  -l, --labels TEXT     Set the issue labels.
  -h, --help            Show this message and exit.
```

- `domains.txt` should contain newline separated integration domain names. The title and body should contain a "template" string `{{ DOMAIN }}` for replacement. If labels are passed the integration domain label will be added.
- The `labels` option can be passed multiple times.